### PR TITLE
[DRWN-1928] Fix Windows MCP CLI execution and harden report/status pa…

### DIFF
--- a/R/mcp_config.R
+++ b/R/mcp_config.R
@@ -1127,10 +1127,32 @@ remove_mcp_config <- function(client = c("cursor", "claude-code", "codex",
   TRUE
 }
 
+# Execute an already-quoted, shell-ready command string (as built by
+# .quote_if_needed() + paste()) and report whether it succeeded.
+#
+# Deliberately uses system() rather than system2(): system2()'s argv-array
+# invocation is only reconstructed correctly by Windows for native .exe
+# targets. When the program resolves to an npm-style .cmd/.ps1 shim (common
+# for CLIs installed via `npm install -g`, including `claude`), Windows must
+# relay the call through cmd.exe, and system2() does so *without* re-quoting
+# args that contain spaces - so e.g. "C:\Program Files\...\Rscript.exe"
+# silently becomes two arguments ("C:\Program" and "Files\...\Rscript.exe").
+# That is exactly how a real config on another machine ended up corrupted
+# (verified by reproducing it locally with an npm-style shim). Executing the
+# identical string already shown to the user keeps "what we print" and "what
+# we run" as one source of truth, correct on every platform and install
+# method system2() could get wrong.
+.run_shell_command <- function(pretty) {
+  out <- tryCatch(
+    system(paste(pretty, "2>&1"), intern = TRUE),
+    error = function(e) structure(conditionMessage(e), status = 1L)
+  )
+  status <- attr(out, "status")
+  list(output = out, ok = is.null(status) || identical(as.integer(status), 0L))
+}
+
 # Run a client CLI when run = TRUE and the program is on PATH; otherwise print
-# the command for the user. Tokens with spaces/quotes are quoted only for the
-# printed line (copy-pasteable in a shell); system2() receives raw args because
-# it does not invoke a shell and embedded quotes become part of the argv value.
+# the command for the user (copy-pasteable in a shell).
 .cli_command <- function(label, program, args, run) {
   args_fmt <- .quote_if_needed(args)
   pretty <- paste(program, paste(args_fmt, collapse = " "))
@@ -1143,16 +1165,11 @@ remove_mcp_config <- function(client = c("cursor", "claude-code", "codex",
                     label, program, pretty))
     return(list(command = pretty, ran = FALSE))
   }
-  out <- tryCatch(
-    system2(program, args = args, stdout = TRUE, stderr = TRUE),
-    error = function(e) structure(conditionMessage(e), status = 1L)
-  )
-  status <- attr(out, "status")
-  ok <- is.null(status) || identical(as.integer(status), 0L)
+  res <- .run_shell_command(pretty)
   message(sprintf("%s: %s\n  %s", label,
-                  if (ok) "ran" else "command FAILED", pretty))
-  if (length(out)) message(paste0("  ", out, collapse = "\n"))
-  list(command = pretty, ran = isTRUE(ok), output = out)
+                  if (res$ok) "ran" else "command FAILED", pretty))
+  if (length(res$output)) message(paste0("  ", res$output, collapse = "\n"))
+  list(command = pretty, ran = isTRUE(res$ok), output = res$output)
 }
 
 # Claude Code user/local: `claude mcp add` errors if the server name already
@@ -1170,11 +1187,29 @@ remove_mcp_config <- function(client = c("cursor", "claude-code", "codex",
                                       collapse = " "))
   combined <- paste(remove_pretty, add_pretty, sep = "\n")
 
+  # `claude mcp add`'s `--` (separating claude's own flags from the launched
+  # command) is only safe to paste manually if the shell preserves it
+  # verbatim. Windows PowerShell's own parameter binder treats a bare `--`
+  # as an "end of named parameters" marker and *strips* it before a target
+  # script ever sees it (verified: `& script.ps1 -- foo` yields $args =
+  # ("foo") only, `--` gone) - so if `claude` was installed via `npm install
+  # -g` (an npm .cmd/.ps1 shim pair, rather than the native installer's
+  # .exe) and this line is pasted into PowerShell, `claude` never receives
+  # the `--` it expects and can misinterpret the launch command. This only
+  # bites the manual copy-paste path below; run = TRUE never hits it
+  # (system() shells out directly, bypassing PowerShell's script binder).
+  ps1_note <- paste(
+    "  Note: if 'claude' was installed via npm (not the native installer),",
+    "pasting this into Windows PowerShell can silently drop the '--'",
+    "separator and break this command - use Command Prompt instead, or",
+    "rerun with run = TRUE so it executes directly."
+  )
+
   if (!isTRUE(run)) {
     message(sprintf(
       paste0("%s - run (remove-then-add so an existing entry is replaced):\n",
-             "  %s\n  %s"),
-      label, remove_pretty, add_pretty
+             "  %s\n  %s\n%s"),
+      label, remove_pretty, add_pretty, ps1_note
     ))
     return(list(command = combined, remove_command = remove_pretty,
                 add_command = add_pretty, ran = FALSE))
@@ -1182,35 +1217,29 @@ remove_mcp_config <- function(client = c("cursor", "claude-code", "codex",
   if (!nzchar(Sys.which("claude"))) {
     message(sprintf(
       paste0("%s: 'claude' not found on PATH - run manually:\n",
-             "  %s\n  %s"),
-      label, remove_pretty, add_pretty
+             "  %s\n  %s\n%s"),
+      label, remove_pretty, add_pretty, ps1_note
     ))
     return(list(command = combined, remove_command = remove_pretty,
                 add_command = add_pretty, ran = FALSE))
   }
 
-  rem_out <- tryCatch(
-    system2("claude", args = remove_args,
-            stdout = TRUE, stderr = TRUE),
-    error = function(e) structure(conditionMessage(e), status = 1L)
-  )
-  rem_status <- attr(rem_out, "status")
-  rem_ok <- is.null(rem_status) || identical(as.integer(rem_status), 0L)
-  rem_txt <- paste(rem_out, collapse = "\n")
+  rem_res <- .run_shell_command(remove_pretty)
+  rem_txt <- paste(rem_res$output, collapse = "\n")
   rem_missing <- grepl("No MCP server named", rem_txt, fixed = TRUE)
-  if (!rem_ok && !rem_missing) {
+  if (!rem_res$ok && !rem_missing) {
     message(sprintf("%s: remove FAILED\n  %s", label, remove_pretty))
-    if (length(rem_out)) message(paste0("  ", rem_out, collapse = "\n"))
+    if (length(rem_res$output)) message(paste0("  ", rem_res$output, collapse = "\n"))
     return(list(command = combined, remove_command = remove_pretty,
-                add_command = add_pretty, ran = FALSE, output = rem_out))
+                add_command = add_pretty, ran = FALSE, output = rem_res$output))
   }
   message(sprintf(
     "%s: %s\n  %s",
     label,
-    if (rem_ok) "removed existing entry" else "no existing entry to remove",
+    if (rem_res$ok) "removed existing entry" else "no existing entry to remove",
     remove_pretty
   ))
-  if (length(rem_out)) message(paste0("  ", rem_out, collapse = "\n"))
+  if (length(rem_res$output)) message(paste0("  ", rem_res$output, collapse = "\n"))
 
   add_rec <- .cli_command(label, "claude", add_args, run = TRUE)
   list(

--- a/R/mcp_config.R
+++ b/R/mcp_config.R
@@ -343,7 +343,8 @@ write_mcp_config <- function(client = c("cursor", "claude-code", "codex",
     # equivalent CLI command is reported for reference only.
     rec <- list(command = sprintf(
       "codex mcp add %s -- %s %s",
-      server_name, command, paste(.quote_if_needed(codex_args), collapse = " ")
+      server_name, .quote_if_needed(command),
+      paste(.quote_if_needed(codex_args), collapse = " ")
     ), ran = FALSE)
     message(sprintf("Codex (user scope): wrote '%s' in %s",
                     server_name, config_written))
@@ -1154,8 +1155,10 @@ remove_mcp_config <- function(client = c("cursor", "claude-code", "codex",
 # Run a client CLI when run = TRUE and the program is on PATH; otherwise print
 # the command for the user (copy-pasteable in a shell).
 .cli_command <- function(label, program, args, run) {
-  args_fmt <- .quote_if_needed(args)
-  pretty <- paste(program, paste(args_fmt, collapse = " "))
+  # Quote program as well as args: Windows system() takes everything up to the
+  # first unquoted space as the executable, so an absolute path under e.g.
+  # C:/Users/First Last/... would be truncated without this.
+  pretty <- paste(.quote_if_needed(c(program, args)), collapse = " ")
   if (!isTRUE(run)) {
     message(sprintf("%s - run:\n  %s", label, pretty))
     return(list(command = pretty, ran = FALSE))

--- a/R/mcp_project_status.R
+++ b/R/mcp_project_status.R
@@ -30,6 +30,43 @@
   list(package = pkg, status_hook = hook, status = status)
 }
 
+# normalizePath(mustWork = FALSE) only fully resolves the components of a
+# path up to the first one that doesn't exist yet; for a not-yet-written
+# repro script this can hand back Windows 8.3 short names (e.g. "MTOMAS~1")
+# for parent directories that DO exist, while a separately-normalized
+# project_dir resolves to the long name - a spurious mismatch. Recurse up to
+# the nearest existing ancestor to canonicalize, then reattach the
+# not-yet-existing remainder verbatim (nothing to resolve there).
+.mcp_normalize_path_lenient <- function(path) {
+  if (file.exists(path)) {
+    return(normalizePath(path, winslash = "/", mustWork = FALSE))
+  }
+  parent <- dirname(path)
+  if (identical(parent, path)) return(gsub("\\\\", "/", path))
+  file.path(.mcp_normalize_path_lenient(parent), basename(path))
+}
+
+# TRUE when the active repro script is not rooted under `project_dir` - e.g.
+# a provider launched a job with a project_dir the session recorder was never
+# pointed at (mcp_session_project_dir() was never called or was set for a
+# different project), so the "executed script" a user would replay silently
+# describes a different project than the one they asked about. Best-effort:
+# an unresolvable directory is never flagged. Reads the recorder's internal
+# path state directly (rather than mcp_repro_path(), which lazily creates a
+# default under tempdir() the first time it's called) so a session where
+# recording simply has not started yet is "no mismatch", not a false
+# positive against tempdir().
+.mcp_repro_project_mismatch <- function(project_dir) {
+  repro <- .mcp_repro_state$path
+  if (is.null(repro) || !nzchar(repro)) return(FALSE)
+  proj_abs <- tryCatch(.mcp_normalize_path_lenient(project_dir),
+                       error = function(e) NA_character_)
+  repro_abs <- tryCatch(.mcp_normalize_path_lenient(repro),
+                        error = function(e) NA_character_)
+  if (is.na(proj_abs) || is.na(repro_abs)) return(FALSE)
+  !startsWith(repro_abs, proj_abs)
+}
+
 # A best-effort "what's next" hint pulled from whichever provider's status
 # names a `recommended_next_phase` (Certara.RsNLME's project-workflow status
 # does); returns NA when no provider offers one. Provider-specific, so this
@@ -66,8 +103,11 @@
 #' @return A list with `project_dir`, `providers` (one entry per provider that
 #'   declares a `status_hook`: `package`, `status_hook`, and either `status`
 #'   or `error`), `next_gated_phase` (a best-effort hint from whichever
-#'   provider's status names one, or `NULL`), `repro_script`, and
-#'   `report_rmd` (this session's own accumulated artifacts).
+#'   provider's status names one, or `NULL`), `repro_script`, `report_rmd`
+#'   (this session's own accumulated artifacts), and
+#'   `repro_project_mismatch` (`TRUE` when `repro_script` is not rooted under
+#'   `project_dir` - the session recorder was never pointed at this project,
+#'   so it is not a faithful replay of work done here).
 #' @keywords internal
 #' @export
 get_certara_project_status <- function(project_dir = ".", dev_roots = character(0)) {
@@ -79,18 +119,29 @@ get_certara_project_status <- function(project_dir = ".", dev_roots = character(
       providers[[length(providers) + 1L]] <- entry
     }
   }
+  mismatch <- .mcp_repro_project_mismatch(project_dir)
   list(
     project_dir = normalizePath(project_dir, mustWork = FALSE),
     providers = providers,
     next_gated_phase = .mcp_status_next_phase(providers),
     repro_script = mcp_repro_path(),
     report_rmd = mcp_report_path(),
+    repro_project_mismatch = mismatch,
     note = paste(
       "Merged from each discovered provider's own status_hook; a provider",
       "with no status_hook is simply absent here. Provider-local artifacts",
       "(run/session directories, plan/decisions files, repro scripts) remain",
       "the source of truth - this surfaces their pointers, not their",
-      "content."
+      "content.",
+      if (isTRUE(mismatch)) {
+        paste(
+          "WARNING: repro_script is not rooted under project_dir - it does",
+          "not describe work done in this project. Call",
+          "mcp_session_project_dir(project_dir) to re-point the recorder."
+        )
+      } else {
+        NULL
+      }
     )
   )
 }

--- a/R/mcp_project_status.R
+++ b/R/mcp_project_status.R
@@ -46,6 +46,21 @@
   file.path(.mcp_normalize_path_lenient(parent), basename(path))
 }
 
+# TRUE when `path` is `root` itself or a true descendant. Both sides are
+# expected to already use `/` separators (as from .mcp_normalize_path_lenient()).
+# A bare startsWith() would treat a sibling whose name merely begins with
+# `root` (e.g. /tmp/proj vs /tmp/proj2) as rooted under it; requiring a path
+# boundary after the root avoids that. On Windows the file system is
+# case-insensitive, so compare case-folded.
+.mcp_path_within <- function(path, root) {
+  root <- sub("/+$", "", root)
+  if (.Platform$OS.type == "windows") {
+    path <- tolower(path)
+    root <- tolower(root)
+  }
+  identical(path, root) || startsWith(path, paste0(root, "/"))
+}
+
 # TRUE when the active repro script is not rooted under `project_dir` - e.g.
 # a provider launched a job with a project_dir the session recorder was never
 # pointed at (mcp_session_project_dir() was never called or was set for a
@@ -64,7 +79,7 @@
   repro_abs <- tryCatch(.mcp_normalize_path_lenient(repro),
                         error = function(e) NA_character_)
   if (is.na(proj_abs) || is.na(repro_abs)) return(FALSE)
-  !startsWith(repro_abs, proj_abs)
+  !.mcp_path_within(repro_abs, proj_abs)
 }
 
 # A best-effort "what's next" hint pulled from whichever provider's status

--- a/R/mcp_report.R
+++ b/R/mcp_report.R
@@ -241,14 +241,25 @@ mcp_report_chunk <- function(code, section, key = NULL) {
       } else {
         ""
       }
+      # error=FALSE is a defense-in-depth backstop; the file.exists() guard
+      # below is the actual fix - a figure recorded before a job re-run (or
+      # cleaned artifacts dir) removed its PNG used to halt the whole
+      # render with an opaque knitr error instead of rendering everything
+      # else that IS still valid.
       opts <- if (nzchar(cap) || nzchar(w)) {
-        paste0("```{r ", label, ", echo=FALSE, fig.align='center'",
+        paste0("```{r ", label, ", echo=FALSE, error=FALSE, fig.align='center'",
                if (nzchar(cap)) paste0(", ", cap) else "",
                w, "}")
       } else {
-        paste0("```{r ", label, ", echo=FALSE, fig.align='center'}")
+        paste0("```{r ", label, ", echo=FALSE, error=FALSE, fig.align='center'}")
       }
-      c("", opts, paste0("knitr::include_graphics('", item$path, "')"),
+      esc_path <- gsub("'", "\\\\'", item$path)
+      c("", opts,
+        sprintf("if (file.exists('%s')) {", esc_path),
+        sprintf("  knitr::include_graphics('%s')", esc_path),
+        "} else {",
+        sprintf("  cat('_Figure not found: %s_')", esc_path),
+        "}",
         "```", "")
     },
     chunk = {
@@ -358,6 +369,13 @@ render_certara_report <- function(output = "html") {
     return(invisible(NULL))
   }
   output_format <- if (identical(output, "html")) "html_document" else output
-  out <- rmarkdown::render(path, output_format = output_format, quiet = TRUE)
+  # Figure paths are recorded relative to the Rmd's own directory (see
+  # .mcp_report_rel_path()), which only resolves correctly if knitting
+  # happens from that directory. Without pinning knit_root_dir, knitr
+  # instead defaults to the *caller's* working directory at render time -
+  # so a render invoked from anywhere else silently re-resolves every
+  # relative figure path against the wrong base and fails.
+  out <- rmarkdown::render(path, output_format = output_format, quiet = TRUE,
+                           knit_root_dir = dirname(path))
   invisible(out)
 }

--- a/man/get_certara_project_status.Rd
+++ b/man/get_certara_project_status.Rd
@@ -16,8 +16,11 @@ get_certara_project_status(project_dir = ".", dev_roots = character(0))
 A list with \code{project_dir}, \code{providers} (one entry per provider that
 declares a \code{status_hook}: \code{package}, \code{status_hook}, and either \code{status}
 or \code{error}), \code{next_gated_phase} (a best-effort hint from whichever
-provider's status names one, or \code{NULL}), \code{repro_script}, and
-\code{report_rmd} (this session's own accumulated artifacts).
+provider's status names one, or \code{NULL}), \code{repro_script}, \code{report_rmd}
+(this session's own accumulated artifacts), and
+\code{repro_project_mismatch} (\code{TRUE} when \code{repro_script} is not rooted under
+\code{project_dir} - the session recorder was never pointed at this project,
+so it is not a faithful replay of work done here).
 }
 \description{
 Calls every discovered provider's optional \code{status_hook} (declared in its

--- a/man/remove_mcp_config.Rd
+++ b/man/remove_mcp_config.Rd
@@ -33,9 +33,12 @@ string literal.}
 \item{run}{For CLI-managed targets (Claude Code user/local scope), actually
 execute the client CLI when it is on \code{PATH} instead of only printing the
 command. Falls back to printing if the CLI is not found. Default \code{FALSE}.
-Codex is configured by writing \verb{~/.codex/config.toml} directly (the only way
-to set per-tool approvals), so \code{run} does not invoke the Codex CLI; the
-equivalent \verb{codex mcp add} command is reported for reference.}
+Claude Code's \verb{claude mcp add} refuses when the server name already exists,
+so this path always remove-then-adds (soft-remove if absent) so a stale
+launcher (e.g. an old \code{Certara.RsNLME::launch_certara_mcp} entry) is
+replaced. Codex is configured by writing \verb{~/.codex/config.toml} directly
+(the only way to set per-tool approvals), so \code{run} does not invoke the
+Codex CLI; the equivalent \verb{codex mcp add} command is reported for reference.}
 }
 \value{
 Invisibly, a list describing actions taken (paths edited, commands).

--- a/man/write_mcp_config.Rd
+++ b/man/write_mcp_config.Rd
@@ -90,9 +90,9 @@ command. Falls back to printing if the CLI is not found. Default \code{FALSE}.
 Claude Code's \verb{claude mcp add} refuses when the server name already exists,
 so this path always remove-then-adds (soft-remove if absent) so a stale
 launcher (e.g. an old \code{Certara.RsNLME::launch_certara_mcp} entry) is
-replaced. Codex is configured by writing \verb{~/.codex/config.toml} directly (the only way
-to set per-tool approvals), so \code{run} does not invoke the Codex CLI; the
-equivalent \verb{codex mcp add} command is reported for reference.}
+replaced. Codex is configured by writing \verb{~/.codex/config.toml} directly
+(the only way to set per-tool approvals), so \code{run} does not invoke the
+Codex CLI; the equivalent \verb{codex mcp add} command is reported for reference.}
 
 \item{job_watch_wait_seconds}{Optional override for the per-call server-side
 job-watch budget (seconds) baked into the launch command, used by

--- a/tests/testthat/test-mcp-config.R
+++ b/tests/testthat/test-mcp-config.R
@@ -365,6 +365,45 @@ test_that(".cli_command preserves multi-word args through an npm-style .cmd shim
   expect_false(any(grepl("^C:\\\\Program$", rec$output)))
 })
 
+test_that(".cli_command quotes a program path that contains spaces", {
+  # Display path: the pretty command must quote the program so a copy-paste
+  # (and system() on Windows) does not truncate at the first space.
+  program <- "C:/Users/First Last/bin/fakecli"
+  rec <- suppressMessages(
+    .cli_command("Fake CLI", program, c("mcp", "add", "certara-r"), run = FALSE)
+  )
+  expect_false(isTRUE(rec$ran))
+  expect_match(rec$command, "\"C:/Users/First Last/bin/fakecli\"", fixed = TRUE)
+  expect_false(grepl("^C:/Users/First ", rec$command))
+})
+
+test_that(".cli_command runs a program whose path contains spaces (Windows)", {
+  # Runtime path: Windows system() takes everything up to the first unquoted
+  # space as the executable, so a shim under a spaced directory must be
+  # quoted or the call never finds it.
+  skip_on_os(c("mac", "linux", "solaris"))
+  parent <- withr::local_tempdir()
+  shim_dir <- file.path(parent, "spaced dir")
+  dir.create(shim_dir)
+  rscript <- file.path(R.home("bin"), "Rscript.exe")
+  echo_r <- file.path(shim_dir, "echoargs.R")
+  writeLines(c(
+    "args <- commandArgs(trailingOnly = TRUE)",
+    "cat(paste(args, collapse = '|'))"
+  ), echo_r)
+  shim_cmd <- file.path(shim_dir, "fakecli.cmd")
+  writeLines(sprintf('@ECHO off\n"%s" "%s" %%*', rscript, echo_r), shim_cmd)
+
+  multiword_arg <- "C:\\Program Files\\Some Vendor\\thing.exe"
+  rec <- suppressMessages(
+    .cli_command("Fake CLI", shim_cmd, c("mcp", "add", "--", multiword_arg),
+                run = TRUE)
+  )
+  expect_true(isTRUE(rec$ran))
+  expect_match(rec$command, "\"", fixed = TRUE)
+  expect_true(any(grepl(multiword_arg, rec$output, fixed = TRUE)))
+})
+
 test_that("launch expression encodes btw groups and session flag", {
   expr <- .mcp_launch_expr(c("docs", "pkg"), FALSE, "certara-r")
   expect_match(expr, "launch_certara_mcp")

--- a/tests/testthat/test-mcp-config.R
+++ b/tests/testthat/test-mcp-config.R
@@ -207,6 +207,20 @@ test_that("claude-code user scope passes -s user to the CLI", {
   })
 })
 
+test_that("claude-code add/remove guidance warns about PowerShell stripping '--'", {
+  # The printed `claude mcp add ... -- <command> <args>` line is only safe to
+  # paste into PowerShell if `claude` is a native .exe; npm's .ps1/.cmd shims
+  # have their `--` silently stripped by PowerShell's own parameter binder
+  # before `claude` ever sees it. run = FALSE (the default) is exactly the
+  # manual copy-paste path, so it must carry this warning.
+  proj <- file.path(tempdir(), paste0("mcpcfg_ccwarn_", as.integer(Sys.time())))
+  dir.create(proj, showWarnings = FALSE, recursive = TRUE)
+  expect_message(
+    write_mcp_config(client = "claude-code", scope = "local", project_dir = proj),
+    "PowerShell can silently drop the '--'"
+  )
+})
+
 test_that("claude-code local scope passes -s local to the CLI", {
   proj <- file.path(tempdir(), paste0("mcpcfg_cclocal_", as.integer(Sys.time())))
   dir.create(proj, showWarnings = FALSE, recursive = TRUE)
@@ -317,6 +331,38 @@ test_that("run = TRUE falls back to printing when the CLI is absent", {
   )
   expect_false(isTRUE(rec$ran))
   expect_match(rec$command, "certara-rsnlme-definitely-missing-codex-cli mcp remove")
+})
+
+test_that(".cli_command preserves multi-word args through an npm-style .cmd shim", {
+  # Regression test for a real-world corrupted MCP config: system2()'s
+  # argv-array invocation is only reconstructed correctly by Windows for
+  # native .exe targets. When the target is an npm-style .cmd/.ps1 shim
+  # (how many CLIs, including `claude`, are installed via `npm install -g`),
+  # Windows must relay through cmd.exe, and system2() does so *without*
+  # re-quoting args containing spaces - so e.g. a "C:\Program Files\..."
+  # path silently becomes two arguments. .cli_command()/.run_shell_command()
+  # must instead execute the identical pre-quoted string shown to the user,
+  # which cmd.exe parses correctly.
+  skip_on_os(c("mac", "linux", "solaris"))
+  shim_dir <- withr::local_tempdir()
+  rscript <- file.path(R.home("bin"), "Rscript.exe")
+  echo_r <- file.path(shim_dir, "echoargs.R")
+  writeLines(c(
+    "args <- commandArgs(trailingOnly = TRUE)",
+    "cat(paste(args, collapse = '|'))"
+  ), echo_r)
+  shim_cmd <- file.path(shim_dir, "fakecli.cmd")
+  writeLines(sprintf('@ECHO off\n"%s" "%s" %%*', rscript, echo_r), shim_cmd)
+
+  multiword_arg <- "C:\\Program Files\\Some Vendor\\thing.exe"
+  rec <- suppressMessages(
+    .cli_command("Fake CLI", shim_cmd, c("mcp", "add", "--", multiword_arg),
+                run = TRUE)
+  )
+  expect_true(isTRUE(rec$ran))
+  expect_true(any(grepl(multiword_arg, rec$output, fixed = TRUE)))
+  # The corrupted-config failure mode: the path silently split at its space.
+  expect_false(any(grepl("^C:\\\\Program$", rec$output)))
 })
 
 test_that("launch expression encodes btw groups and session flag", {

--- a/tests/testthat/test-mcp-project-status.R
+++ b/tests/testthat/test-mcp-project-status.R
@@ -102,6 +102,35 @@ test_that(".mcp_repro_project_mismatch is TRUE when the repro script lives elsew
   expect_true(.mcp_repro_project_mismatch(proj))
 })
 
+test_that(".mcp_path_within requires a path boundary (not a bare prefix)", {
+  expect_true(.mcp_path_within("/tmp/proj/scripts/repro.R", "/tmp/proj"))
+  expect_true(.mcp_path_within("/tmp/proj", "/tmp/proj"))
+  expect_true(.mcp_path_within("/tmp/proj/", "/tmp/proj"))
+  expect_false(.mcp_path_within("/tmp/proj2/scripts/repro.R", "/tmp/proj"))
+  expect_false(.mcp_path_within("/tmp/other/repro.R", "/tmp/proj"))
+})
+
+test_that(".mcp_path_within is case-insensitive on Windows", {
+  skip_on_os(c("mac", "linux", "solaris"))
+  expect_true(.mcp_path_within("C:/Users/Me/proj/repro.R", "c:/users/me/proj"))
+  expect_true(.mcp_path_within("C:/Users/Me/Proj/repro.R", "C:/Users/ME/PROJ"))
+  expect_false(.mcp_path_within("C:/Users/Me/proj2/repro.R", "c:/users/me/proj"))
+})
+
+test_that(".mcp_repro_project_mismatch treats a sibling-prefix directory as a mismatch", {
+  # Bare startsWith("/tmp/proj", "/tmp/proj") would also match "/tmp/proj2/...";
+  # requiring a path boundary after the root rejects that false negative.
+  mcp_repro_reset()
+  on.exit(mcp_repro_reset(), add = TRUE)
+  parent <- withr::local_tempdir()
+  proj <- file.path(parent, "proj")
+  sibling <- file.path(parent, "proj2")
+  dir.create(proj)
+  dir.create(sibling)
+  mcp_repro_path(file.path(sibling, "certara_mcp_repro.R"))
+  expect_true(.mcp_repro_project_mismatch(proj))
+})
+
 test_that("get_certara_project_status surfaces repro_project_mismatch and warns in note", {
   local_mocked_bindings(
     .mcp_discover_tool_providers = function(dev_roots = character(0)) {

--- a/tests/testthat/test-mcp-project-status.R
+++ b/tests/testthat/test-mcp-project-status.R
@@ -75,3 +75,46 @@ test_that("get_certara_project_status returns no next_gated_phase when no provid
   expect_length(out$providers, 0)
   expect_null(out$next_gated_phase)
 })
+
+test_that(".mcp_repro_project_mismatch is FALSE when the repro path is unset", {
+  mcp_repro_reset()
+  on.exit(mcp_repro_reset(), add = TRUE)
+  # No path ever set: mcp_repro_path() lazily resolves under tempdir(), which
+  # is never "under" an arbitrary project dir, but an unset recorder simply
+  # has not started yet -- that is not the same failure as a stale one.
+  expect_false(.mcp_repro_project_mismatch(withr::local_tempdir()))
+})
+
+test_that(".mcp_repro_project_mismatch is FALSE when the repro script is rooted under project_dir", {
+  mcp_repro_reset()
+  on.exit(mcp_repro_reset(), add = TRUE)
+  proj <- withr::local_tempdir()
+  mcp_repro_path(file.path(proj, "scripts", "certara_mcp_repro.R"))
+  expect_false(.mcp_repro_project_mismatch(proj))
+})
+
+test_that(".mcp_repro_project_mismatch is TRUE when the repro script lives elsewhere", {
+  mcp_repro_reset()
+  on.exit(mcp_repro_reset(), add = TRUE)
+  other <- withr::local_tempdir()
+  mcp_repro_path(file.path(other, "certara_mcp_repro.R"))
+  proj <- withr::local_tempdir()
+  expect_true(.mcp_repro_project_mismatch(proj))
+})
+
+test_that("get_certara_project_status surfaces repro_project_mismatch and warns in note", {
+  local_mocked_bindings(
+    .mcp_discover_tool_providers = function(dev_roots = character(0)) {
+      list(providers = list(), skipped = list())
+    }
+  )
+  mcp_repro_reset()
+  on.exit(mcp_repro_reset(), add = TRUE)
+  other <- withr::local_tempdir()
+  mcp_repro_path(file.path(other, "certara_mcp_repro.R"))
+  proj <- withr::local_tempdir()
+
+  out <- get_certara_project_status(project_dir = proj)
+  expect_true(out$repro_project_mismatch)
+  expect_match(out$note, "WARNING", fixed = TRUE)
+})

--- a/tests/testthat/test-mcp-report.R
+++ b/tests/testthat/test-mcp-report.R
@@ -123,3 +123,71 @@ test_that("render_certara_report warns without rmarkdown", {
   mcp_report_init("No render")
   expect_warning(render_certara_report(), "rmarkdown")
 })
+
+test_that("figure chunk guards a missing PNG instead of failing the whole render", {
+  mcp_report_reset()
+  mcp_session_paths_reset()
+  root <- file.path(tempdir(), "mcp_fig_missing")
+  on.exit({
+    unlink(root, recursive = TRUE)
+    mcp_report_reset()
+    mcp_session_paths_reset()
+  }, add = TRUE)
+  mcp_session_project_dir(root)
+  # Figure recorded but never actually written (e.g. a re-run cleaned the
+  # artifacts dir after this report entry was made).
+  missing_fig <- file.path(root, "figures", "gof_dv_vs_pred.png")
+  mcp_report_figure(missing_fig, "DV vs PRED", section = "diagnostics.gof",
+                    key = "gof_dv")
+  txt <- mcp_report_read()
+  expect_match(txt, "error=FALSE", fixed = TRUE)
+  expect_match(txt, "if (file.exists(", fixed = TRUE)
+  expect_match(txt, "Figure not found", fixed = TRUE)
+})
+
+test_that("render_certara_report pins knit_root_dir to the report's own directory", {
+  mcp_report_reset()
+  mcp_session_paths_reset()
+  root <- file.path(tempdir(), "mcp_report_knit_root")
+  on.exit({
+    unlink(root, recursive = TRUE)
+    mcp_report_reset()
+    mcp_session_paths_reset()
+  }, add = TRUE)
+  mcp_session_project_dir(root)
+  mcp_report_init("Knit root test")
+  captured <- NULL
+  local_mocked_bindings(
+    render = function(input, output_format, quiet, knit_root_dir, ...) {
+      captured <<- knit_root_dir
+      "rendered.html"
+    },
+    pandoc_available = function(...) TRUE,
+    .package = "rmarkdown"
+  )
+  render_certara_report()
+  expect_equal(normalizePath(captured, winslash = "/"),
+              normalizePath(dirname(mcp_report_path()), winslash = "/"))
+})
+
+test_that("render_certara_report succeeds when invoked from a different working directory", {
+  skip_if_not_installed("rmarkdown")
+  skip_if_not(rmarkdown::pandoc_available())
+  mcp_report_reset()
+  mcp_session_paths_reset()
+  root <- file.path(tempdir(), "mcp_report_cwd_indep")
+  on.exit({
+    unlink(root, recursive = TRUE)
+    mcp_report_reset()
+    mcp_session_paths_reset()
+  }, add = TRUE)
+  mcp_session_project_dir(root)
+  fig <- file.path(root, "figures", "gof_dv_vs_pred.png")
+  dir.create(dirname(fig), recursive = TRUE, showWarnings = FALSE)
+  writeLines("png", fig)
+  mcp_report_figure(fig, "DV vs PRED", section = "diagnostics.gof", key = "gof_dv")
+
+  elsewhere <- withr::local_tempdir()
+  out <- withr::with_dir(elsewhere, render_certara_report())
+  expect_true(file.exists(out))
+})


### PR DESCRIPTION
…th handling

Use system() for MCP config CLI helpers so npm shims preserve quoted paths on Windows; detect repro-script/project-dir mismatches in project status; and make report rendering tolerant of missing figures and independent of caller working directory.