### PR TITLE
[DRWN-1928] Document PML emission order and soften memory-off MCP errors

### DIFF
--- a/R/mcp_host_tools.R
+++ b/R/mcp_host_tools.R
@@ -321,7 +321,19 @@
     .ctool(
       function(lesson, category = "corrective", trigger = NULL,
                scope = "global", level = NULL) {
-        record_lesson(lesson, category, trigger, scope, level)
+        tryCatch(
+          record_lesson(lesson, category, trigger, scope, level),
+          error = function(e) {
+            msg <- conditionMessage(e)
+            if (grepl("enable_memory", msg, fixed = TRUE) ||
+                grepl("memory is disabled", msg, ignore.case = TRUE)) {
+              list(recorded = FALSE, reason = msg,
+                   next_action = "Certara.R::enable_memory()")
+            } else {
+              stop(e)
+            }
+          }
+        )
       },
       "record_lesson",
       "Record a corrective lesson or endorsed best practice for future sessions.",
@@ -375,7 +387,13 @@
       )
     ),
     .ctool(
-      function() list_memory_records(),
+      function() {
+        out <- list_memory_records()
+        if (!isTRUE(out$enabled)) {
+          out$next_action <- "Certara.R::enable_memory()"
+        }
+        out
+      },
       "list_memory_records",
       paste(
         "Inspect all stored memory records (run memory, lessons, preferences,",

--- a/R/mcp_host_tools.R
+++ b/R/mcp_host_tools.R
@@ -324,10 +324,8 @@
         tryCatch(
           record_lesson(lesson, category, trigger, scope, level),
           error = function(e) {
-            msg <- conditionMessage(e)
-            if (grepl("enable_memory", msg, fixed = TRUE) ||
-                grepl("memory is disabled", msg, ignore.case = TRUE)) {
-              list(recorded = FALSE, reason = msg,
+            if (inherits(e, "certara_memory_disabled")) {
+              list(recorded = FALSE, reason = conditionMessage(e),
                    next_action = "Certara.R::enable_memory()")
             } else {
               stop(e)

--- a/R/mcp_memory.R
+++ b/R/mcp_memory.R
@@ -96,10 +96,10 @@ disable_memory <- function() {
 
 .memory_require_enabled <- function() {
   if (!.memory_enabled()) {
-    stop(
+    stop(errorCondition(
       "Per-user memory is disabled. Enable with enable_memory() (opt-in).",
-      call. = FALSE
-    )
+      class = "certara_memory_disabled"
+    ))
   }
 }
 

--- a/R/mcp_session_status.R
+++ b/R/mcp_session_status.R
@@ -71,7 +71,9 @@
 #' [launch_certara_mcp()] startup.
 #'
 #' @return A structured list with `server`, `session_tools_enabled`,
-#'   `btw_groups`, `live_code_execution`, `environment_inspection`,
+#'   `btw_groups`, `project_dir`, `durability`, `memory` (whether per-user
+#'   memory is on, plus `next_action = "Certara.R::enable_memory()"` when it
+#'   is off), `live_code_execution`, `environment_inspection`,
 #'   `execution_contexts`, `connect_live_session`, and `next_steps`.
 #' @seealso [certara_mcp_capabilities()], [launch_certara_mcp()],
 #'   [write_mcp_config()]

--- a/R/mcp_session_status.R
+++ b/R/mcp_session_status.R
@@ -97,6 +97,14 @@ certara_session_status <- function() {
     btw_groups = if (groups_known) groups else NA_character_,
     project_dir = mcp_session_project_dir(),
     durability = mcp_session_durability(),
+    memory = list(
+      enabled = .memory_enabled(),
+      next_action = if (!isTRUE(.memory_enabled())) {
+        "Certara.R::enable_memory()"
+      } else {
+        NULL
+      }
+    ),
     live_code_execution = list(
       enabled = run_enabled,
       tool = "btw_tool_run_r",

--- a/inst/mcp/WORKFLOW.md
+++ b/inst/mcp/WORKFLOW.md
@@ -170,7 +170,11 @@ hand-writing PML: `Certara.RsNLME.pml.authoring.skeleton` (statement order),
 `...authoring.naming` (conventions), `...authoring.compartment_map` (how
 statements create compartments), `...authoring.builtin_first` (prefer a builtin
 constructor; reserve `textualmodel()` for custom structures), and
-`...pml.parser_quirks` (lexical traps). Then `validate_pml()` and
+`...pml.parser_quirks` (lexical traps). The from-scratch convention matches
+`generatePMLModel()` emission: structural, `error`/`observe`, `stparm`,
+`covariate`/`fcovariate`, extra stparm, `fixef`, `ranef`, optional `secondary`.
+The parser does not require that order (only `sequence{}` is positional); do
+not rewrite valid user-supplied PML just to match it. Then `validate_pml()` and
 `confirm_pml_structure()` before building.
 
 **Translating a NONMEM control stream.** This is understanding-led, not

--- a/inst/mcp/certara-mcp-usage.mdc
+++ b/inst/mcp/certara-mcp-usage.mdc
@@ -280,9 +280,12 @@ run `Naive-Pooled` (or NCA) to stabilize initials and carry them forward.
 
 - **Write PML from scratch:** retrieve the authoring KB first
   (`Certara.RsNLME.pml.authoring.skeleton`, `...naming`, `...compartment_map`,
-  `...builtin_first`, `...pml.parser_quirks`). Prefer a builtin constructor;
-  use `textualmodel` only for custom structures. Then `validate_pml` +
-  `confirm_pml_structure`.
+  `...builtin_first`, `...pml.parser_quirks`). The from-scratch convention
+  matches `generatePMLModel()`: structural, `error`/`observe`, `stparm`,
+  `covariate`/`fcovariate`, extra stparm, `fixef`, `ranef`, optional
+  `secondary`. The parser does not require that order. Prefer a builtin
+  constructor; use `textualmodel` only for custom structures. Then
+  `validate_pml` + `confirm_pml_structure`.
 - **Translate a NONMEM control stream (understanding-led, not one-to-one):**
   1. `analyze_nonmem_control` (read-only) → structure, parameters,
      `recommended_path`, `column_mapping_hint`, `open_questions`, `unsupported`.

--- a/man/certara_session_status.Rd
+++ b/man/certara_session_status.Rd
@@ -8,7 +8,10 @@ certara_session_status()
 }
 \value{
 A structured list with \code{server}, \code{session_tools_enabled},
-\code{btw_groups}, \code{live_code_execution}, \code{environment_inspection},
+\code{btw_groups}, \code{project_dir}, \code{durability}, \code{memory}
+(whether per-user memory is on, plus
+\code{next_action = "Certara.R::enable_memory()"} when it is off),
+\code{live_code_execution}, \code{environment_inspection},
 \code{execution_contexts}, \code{connect_live_session}, and \code{next_steps}.
 }
 \description{

--- a/tests/testthat/test-mcp-memory.R
+++ b/tests/testthat/test-mcp-memory.R
@@ -100,3 +100,30 @@ test_that("record_run round-trips through list_memory_records", {
   expect_match(runs[[1]]$summary, "FOCE-ELS")
   expect_identical(runs[[1]]$kind, "run")
 })
+
+test_that("record_lesson MCP wrapper returns next_action when memory is off", {
+  local_memory()
+  rec <- Filter(function(t) identical(t@name, "record_lesson"),
+                .certara_host_tools("memory"))[[1]]
+  out <- rec(lesson = "do not freeze every residual")
+  expect_false(isTRUE(out$recorded))
+  expect_match(out$reason, "disabled")
+  expect_identical(out$next_action, "Certara.R::enable_memory()")
+  expect_error(record_lesson("x"), "disabled")
+})
+
+test_that("list_memory_records MCP wrapper hints enable_memory when off", {
+  local_memory()
+  lst <- Filter(function(t) identical(t@name, "list_memory_records"),
+                .certara_host_tools("memory"))[[1]]
+  out <- lst()
+  expect_false(isTRUE(out$enabled))
+  expect_identical(out$next_action, "Certara.R::enable_memory()")
+})
+
+test_that("certara_session_status points at enable_memory when memory is off", {
+  local_memory()
+  st <- certara_session_status()
+  expect_false(isTRUE(st$memory$enabled))
+  expect_identical(st$memory$next_action, "Certara.R::enable_memory()")
+})

--- a/tests/testthat/test-mcp-memory.R
+++ b/tests/testthat/test-mcp-memory.R
@@ -109,7 +109,16 @@ test_that("record_lesson MCP wrapper returns next_action when memory is off", {
   expect_false(isTRUE(out$recorded))
   expect_match(out$reason, "disabled")
   expect_identical(out$next_action, "Certara.R::enable_memory()")
-  expect_error(record_lesson("x"), "disabled")
+  err <- tryCatch(record_lesson("x"), error = identity)
+  expect_s3_class(err, "certara_memory_disabled")
+})
+
+test_that("record_lesson MCP wrapper still raises non-disable errors", {
+  local_memory()
+  enable_memory()
+  rec <- Filter(function(t) identical(t@name, "record_lesson"),
+                .certara_host_tools("memory"))[[1]]
+  expect_error(rec(lesson = "x", category = "not_a_category"), "arg")
 })
 
 test_that("list_memory_records MCP wrapper hints enable_memory when off", {


### PR DESCRIPTION
Match WORKFLOW and certara-mcp-usage to generatePMLModel statement order so agents stop authoring stparm-before-structural PML.

When memory is disabled, record_lesson and list_memory_records return next_action = Certara.R::enable_memory() instead of a bare error; surface the same hint on certara_session_status. R-level record_lesson() still errors.